### PR TITLE
lib: Work around a ryml parsing issue for empty, tagged strings in maps

### DIFF
--- a/test/aamp/test_aamp_empty_strings.py
+++ b/test/aamp/test_aamp_empty_strings.py
@@ -1,0 +1,23 @@
+import pytest
+import oead
+from pathlib import Path
+
+
+# Catches possible YAML parsing regressions such as empty, tagged strings being turned
+# into tildes:
+# https://github.com/biojppm/rapidyaml/commit/98d3d9763584313a#commitcomment-42460490
+def test_aamp_empty_strings():
+    with (Path(__file__).parent / "test_empty_strings.yml").open("r") as test_yml:
+        yml_data = test_yml.read()
+    data: oead.aamp.ParameterIO = oead.aamp.ParameterIO.from_text(yml_data)
+    assert data.type == "oead_test"
+    assert data.version == 10
+
+    assert str(data.objects["TestContent"].params["Str64_empty"].v) == ""
+    assert str(data.objects["TestContent"].params["Str64_empty2"].v) == ""
+
+    text_serialized = data.to_text()
+    assert data == oead.aamp.ParameterIO.from_text(text_serialized)
+
+    bin_serialized = data.to_binary()
+    assert data == oead.aamp.ParameterIO.from_binary(bin_serialized)

--- a/test/aamp/test_empty_strings.yml
+++ b/test/aamp/test_empty_strings.yml
@@ -1,0 +1,9 @@
+!io
+version: 10
+type: oead_test
+param_root: !list
+  objects:
+    TestContent: !obj
+      Str64_empty: !str64 ''
+      Str64_empty2: !str64
+  lists: {}


### PR DESCRIPTION
* test/aamp: Add empty, tagged strings to catch rapidyaml regressions

https://github.com/biojppm/rapidyaml/commit/98d3d9763584313a299c2129499d3482b1c933ed#commitcomment-42460490