### PR TITLE
py: Fix a couple of surprising implicit conversions

### DIFF
--- a/py/py_aamp.cpp
+++ b/py/py_aamp.cpp
@@ -59,7 +59,11 @@ static void BindAampParameter(py::module& m) {
       .value("BufferBinary", aamp::Parameter::Type::BufferBinary)
       .value("StringRef", aamp::Parameter::Type::StringRef);
 
-  clas.def(py::init<aamp::Parameter::Value>())
+  clas
+      // This is required to support conversions from F32 to float.
+      // Without this constructor, oead.F32(1.7) is turned into an integer.
+      .def(py::init<F32>())
+      .def(py::init<aamp::Parameter::Value>())
       .def(py::self == py::self)
       .def("__copy__", [](const aamp::Parameter::Value& o) { return aamp::Parameter::Value(o); })
       .def("__deepcopy__",

--- a/src/include/oead/aamp.h
+++ b/src/include/oead/aamp.h
@@ -132,6 +132,7 @@ public:
   Parameter(Parameter&& other) noexcept { *this = std::move(other); }
   template <typename T, std::enable_if_t<std::is_constructible_v<Value, T>>* = nullptr>
   Parameter(T value) : m_value{std::move(value)} {}
+  Parameter(F32 value) : m_value{static_cast<f32>(value)} {}
   Parameter& operator=(const Parameter& other) = default;
   Parameter& operator=(Parameter&& other) noexcept = default;
 


### PR DESCRIPTION
- Try to load oead::{S,U}{8,16,32,64} / oead::F{32,64} first without
  any implicit conversion to prevent explicitly typed values from
  being converted

- Fix aamp.Parameter(oead.F32(x)) implicitly converting the F32
  to an integer (which truncates it)