### PR TITLE
Check whether ryml nodes are valid

### DIFF
--- a/src/aamp_text.cpp
+++ b/src/aamp_text.cpp
@@ -204,6 +204,9 @@ static std::array<oead::Curve, N> ReadSequenceForCurve(const ryml::NodeRef& node
 }
 
 Parameter ReadParameter(const ryml::NodeRef& node) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for Parameter");
+
   if (node.is_seq()) {
     const auto tag = yml::RymlSubstrToStrView(node.val_tag());
 
@@ -254,6 +257,8 @@ Parameter ReadParameter(const ryml::NodeRef& node) {
 
 template <typename Fn, typename Map>
 static void ReadMap(const ryml::NodeRef& node, Map& map, Fn read_fn) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for Map");
   if (!node.is_map())
     throw InvalidDataError("Expected map node");
 
@@ -270,12 +275,18 @@ static void ReadMap(const ryml::NodeRef& node, Map& map, Fn read_fn) {
 }
 
 ParameterObject ReadParameterObject(const ryml::NodeRef& node) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for ParameterObject");
+
   ParameterObject object;
   ReadMap(node, object.params, ReadParameter);
   return object;
 }
 
 ParameterList ReadParameterList(const ryml::NodeRef& node) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for ParameterList");
+
   ParameterList list;
   ReadMap(yml::RymlGetMapItem(node, "objects"), list.objects, ReadParameterObject);
   ReadMap(yml::RymlGetMapItem(node, "lists"), list.lists, ReadParameterList);
@@ -283,6 +294,9 @@ ParameterList ReadParameterList(const ryml::NodeRef& node) {
 }
 
 ParameterIO ReadParameterIO(const ryml::NodeRef& node) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for ParameterIO");
+
   ParameterIO pio;
   pio.version = ParseIntOrFloat<u32>(yml::RymlGetMapItem(node, "version"));
   pio.type = std::move(

--- a/src/byml_text.cpp
+++ b/src/byml_text.cpp
@@ -93,6 +93,9 @@ static bool ShouldUseInlineYamlStyle(const Byml& container) {
 }
 
 Byml ParseYamlNode(const c4::yml::NodeRef& node) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node");
+
   if (node.is_seq()) {
     auto array = Byml::Array{};
     array.reserve(node.num_children());

--- a/src/yaml.cpp
+++ b/src/yaml.cpp
@@ -27,6 +27,7 @@
 #include <c4/error.hpp>
 #include <ryml.hpp>
 
+#include <oead/errors.h>
 #include <oead/util/iterator_utils.h>
 
 namespace oead::yml {
@@ -148,22 +149,30 @@ bool StringNeedsQuotes(const std::string_view value) {
 }
 
 Scalar ParseScalar(const ryml::NodeRef& node, TagRecognizer recognizer) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for ParseScalar");
+
   const std::string_view tag = RymlGetValTag(node);
   const std::string_view value = RymlSubstrToStrView(node.val());
   const char* arena_start = node.tree()->arena().data();
   bool is_quoted = false;
-  if (node.val().data() != arena_start)
-    is_quoted = util::IsAnyOf(*(node.val().data() - 1), '\'', '"');
+  const char* raw_string = node.val().data();
+  if (raw_string != nullptr && raw_string != arena_start)
+    is_quoted = util::IsAnyOf(raw_string[-1], '\'', '"');
   return ParseScalar(tag, value, is_quoted, recognizer);
 }
 
 Scalar ParseScalarKey(const ryml::NodeRef& node, TagRecognizer recognizer) {
+  if (!node.valid())
+    throw InvalidDataError("Invalid YAML node for ParseScalarKey");
+
   const std::string_view tag = RymlGetKeyTag(node);
   const std::string_view value = RymlSubstrToStrView(node.key());
   const char* arena_start = node.tree()->arena().data();
   bool is_quoted = false;
-  if (node.key().data() != arena_start)
-    is_quoted = util::IsAnyOf(*(node.key().data() - 1), '\'', '"');
+  const char* raw_string = node.key().data();
+  if (raw_string != nullptr && raw_string != arena_start)
+    is_quoted = util::IsAnyOf(raw_string[-1], '\'', '"');
   return ParseScalar(tag, value, is_quoted, recognizer);
 }
 


### PR DESCRIPTION
Prevents crashes in release builds. oead should never cause a crash, even in the face of invalid data.