### PR TITLE
Add required files to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include versioneer.py
 include readme.rst
+include CMakeLists.txt
+include CMakeRC.cmake
+recursive-include src *
 recursive-include lib *.*

--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,6 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     ext_modules=[CMakeExtension(name="oead", sourcedir="py")],
+    data_files=[('data', [str(p) for p in Path('data').glob('**/*')])],
     zip_safe=False,
 )


### PR DESCRIPTION
## Description

See #26. Fixes installs from sdist, including on Apple Silicon for which this repo doesn't build a wheel for.

Per the [Python packaging user guide](https://packaging.python.org/en/latest/guides/using-manifest-in/):

>The following files are included in a source distribution by default:
>   * all Python source files implied by the py_modules and packages setup() arguments
>   * all C source files mentioned in the ext_modules or libraries setup() arguments
>   * scripts specified by the scripts setup() argument
>   * all files specified by the package_data and data_files setup() arguments

I added the required `data/` files with `data_files`, but didn't look into adding the `src/` files to `ext_modules`, so I just added them to `MANIFEST.in`, along with the two required CMake files.

## Testing
Building sdist and installing it succeeded:
```
python setup.py sdist
pip install dist/oead-1.2.6.post1+2.g7b3a205.tar.gz
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/oead/28)
<!-- Reviewable:end -->

Fixes #26