### PR TITLE
Update abseil to 20250127.1 to fix mac arm build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ jobs:
     - name: Build SDist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: dist/*.tar.gz
 
 
@@ -27,12 +28,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Universal wheels error on Mac, so use macos-latest for arm, and 13 for x64
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.14"
       CIBW_ARCHS: auto64
-      CIBW_ARCHS_MACOS: "universal2"
-      CIBW_SKIP: cp36-* cp37-*
+      CIBW_SKIP: cp36-* cp37-* cp38-macosx_arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -44,8 +45,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
 
@@ -53,10 +55,16 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist
           path: dist
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.9.0
         with:

--- a/readme.rst
+++ b/readme.rst
@@ -31,9 +31,7 @@ This will download and install a precompiled version of oead for the following p
 
 * Windows (x86-64 / 64-bit)
 * Recent Linux distributions (x86-64, glibc and musl)
-
-Precompiled builds for macOS are currently unavailable as the wheel build process seems to be broken.
-Please help us fix this `release failure <https://github.com/zeldamods/oead/actions/runs/9588470856/job/26440567392>` if you know how!
+* macOS 10.14+ (x86-64 / arm64)
 
 The following versions of Python are supported:
 


### PR DESCRIPTION
Reverts last commit and updates abseil. This is the error obtained from trying to build on an arm Mac:
```
      clang++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin24.4.0'
      make[2]: *** [oead/lib/abseil/absl/random/CMakeFiles/absl_random_internal_randen_hwaes_impl.dir/internal/randen_hwaes.cc.o] Error 1
      make[1]: *** [oead/lib/abseil/absl/random/CMakeFiles/absl_random_internal_randen_hwaes_impl.dir/all] Error 2
```
Searching leads to [this issue](https://github.com/abseil/abseil-cpp/issues/1241), with a linked issue in vcpkg stating that it has been fixed in version 20250127.0. I updated the lib and was able to build and install the wheel on an arm Mac.

The environment variable `CMAKE_POLICY_VERSION_MINIMUM=3.5` may also need to be set if using cmake >=4

Also updates the release workflow to build x64 and arm64 macOS wheels on x64 and arm64 macOS runners, respectively, as trying to build universal wheels always seems to fail. Here's a successful run of the release workflow, with the pypi steps removed: https://github.com/neebyA/oead/actions/runs/15062615767

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/oead/41)
<!-- Reviewable:end -->
