### PR TITLE
py: fix incompatible types being cast to `tcb::span`

### DIFF
--- a/py/pybind11_common.h
+++ b/py/pybind11_common.h
@@ -69,6 +69,9 @@ struct type_caster<tcb::span<T>> {
   }
 
   bool load(handle src, bool) {
+    if (!isinstance<py::sequence>(src) || isinstance<py::str>(src))
+      return false;
+
     const py::buffer_info buffer = src.cast<py::buffer>().request(!std::is_const_v<T>);
     if (buffer.itemsize != sizeof(T) || buffer.ndim != 1)
       return false;


### PR DESCRIPTION
If a function was taking `tcb::span` as a parameter and it was accessed from python, the type caster allows all types through, instead of checking if the type is valid to be cast to `tcb::span`. This just adds a check to stop that from happening.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/oead/49)
<!-- Reviewable:end -->
